### PR TITLE
add pString to parse any string

### DIFF
--- a/src/Fable.Import.Virtualdom/Fable.Helpers.RouteParser.fs
+++ b/src/Fable.Import.Virtualdom/Fable.Helpers.RouteParser.fs
@@ -277,6 +277,13 @@ module Parsing =
         |> mapP charListToStr 
         <?> label
 
+    let pString = 
+        let label = "string"
+        let predicate = fun _ -> true
+        satisfy predicate "string"
+        |> many
+        |> mapP charListToStr
+
     let pStringTo endingChar = 
         let label = sprintf "string up to char %c" endingChar
         let ending = pchar endingChar

--- a/src/Fable.Import.Virtualdom/RouteParserTesting.fsx
+++ b/src/Fable.Import.Virtualdom/RouteParserTesting.fsx
@@ -1,3 +1,4 @@
+#r "./node_modules/fable-core/Fable.Core.dll"
 #load "./Fable.Helpers.RouteParser.fs"
 
 module RouteParserTesting = 
@@ -15,10 +16,11 @@ module RouteParserTesting =
         | Home5 of Guid*int*int*int*int
         | User of Guid*int*float
         | Admin of Guid
+        | NotFound of string
     let routes = [
         runM Home (pStaticStr "home" |> (drop >> _end))
-        runM2 HomeStrInt (pStringTo '/' .>>. pint )
-        runM1 HomeStr (pStringTo '/')
+        runM2 HomeStrInt (pStringTo '/' .>>. pint |> _end)
+        runM1 HomeStr (pStringTo '/' |> _end)
         runM1 Home1 (pStaticStr "home" </.> pguid |> _end) 
         runM2 Home2 (pStaticStr "home" </.> pguid </> pint |> _end) 
         runM3 Home3 (pStaticStr "home" </.> pguid </> pint </> pint |> _end) 
@@ -26,6 +28,7 @@ module RouteParserTesting =
         runM5 Home5 (pStaticStr "home" </.> pguid </> pint </> pint </> pint </> pint |> _end) 
         runM3 User (pStaticStr "user" </.> pguid </> pint <./> pStaticStr "yolo" </> pfloat |> _end) 
         runM2 (fun (g,_) -> Admin g) (pStaticStr "admin" </.> pguid </> pint |> _end) 
+        runM1 NotFound pString
     ]
     let run() = 
         [
@@ -40,7 +43,7 @@ module RouteParserTesting =
             "home/30FF82ab-2861-43f5-8b68-3b52e2b3ddbc/123121/1/323/232"
             "home/30FF82ab-2861-43f5-8b68-3b52e2b3ddbc/123121/2342/234234/23432"
             "user/30ff82ab-2861-43f5-8b68-3b52e2b3ddbc/123121/yolo/34.23"
-            "admin/30FF82ab-2861-43f5-8b68-3b52e2b3ddbc/123121/"
+            "admin/30FF82ab-2861-43f5-8b68-3b52e2b3ddbc/123121"
             "30FF82ab-2861-43f5-8b68-3b52e2b3ddbc/123121xxxz"
         ] |> List.iter (fun i -> printfn "%A" (choose routes i))
 

--- a/src/Fable.Import.Virtualdom/package.json
+++ b/src/Fable.Import.Virtualdom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fable-import-virtualdom",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Fable bindings for virtual-dom",
   "repository": {
     "type": "git",


### PR DESCRIPTION
`pString` matches any string, which makes it possible to have a catch all at the end in a `choose` list to have `404` route.
