### PR TITLE
Feature/removemailboxprocessor

### DIFF
--- a/samples/navigation/hello.fsx
+++ b/samples/navigation/hello.fsx
@@ -61,7 +61,7 @@ let view model =
 // some of the other more advanced examples for how to
 // use createApp. In addition to the application functions
 // we also need to specify which renderer to use.
-createApp initValue view update Virtualdom.renderer
+createApp initValue view update Virtualdom.createRender
 |> withNavigation urlParser urlUpdate
 |> withStartNodeSelector "#hello"
 |> start

--- a/samples/plugin/plugin.fsx
+++ b/samples/plugin/plugin.fsx
@@ -104,7 +104,7 @@ let resetEveryTenth h =
     window.setInterval((fun _ -> Reset |> h), 10000) |> ignore
 
 let initModel = {Top = 0; Bottom = 0}
-createSimpleApp initModel nestedView nestedUpdate Virtualdom.renderer
+createSimpleApp initModel nestedView nestedUpdate Virtualdom.createRender
 |> withStartNodeSelector "#nested-counter"
 //#if DEV
 |> withPlugin (Fable.Arch.DevTools.createDevTools<NestedAction, NestedModel> "something" initModel)

--- a/src/Fable.Arch/Fable.Arch.App.fs
+++ b/src/Fable.Arch/Fable.Arch.App.fs
@@ -8,6 +8,8 @@ open Html
 
 [<AutoOpen>]
 module Types =
+    type Handler<'TMessage> = 'TMessage -> unit
+
     type ModelChanged<'TMessage, 'TModel> = 
         {
             PreviousState: 'TModel
@@ -25,7 +27,7 @@ module Types =
         | Replay of 'TModel*((System.Guid*'TMessage) list)
         | Draw
 
-    type Action<'TMessage> = ('TMessage -> unit) -> unit
+    type Action<'TMessage> = Handler<'TMessage> -> unit
 
     type Subscriber<'TMessage, 'TModel> = AppEvent<'TMessage, 'TModel> -> unit
     type Producer<'TMessage, 'TModel> = Action<AppMessage<'TMessage, 'TModel>>
@@ -40,33 +42,29 @@ module Types =
         | NoRequest
 
 type ScheduleMessage = 
-    | PingIn of float*(unit -> unit)
+    | PingIn of float*Handler<unit>
 
 type Selector = string
-type Renderer<'TMessage, 'TView, 'TViewState> = 
-    {
-        Render: ('TMessage -> unit) -> 'TView -> 'TViewState -> 'TViewState
-        Init: Selector -> ('TMessage -> unit) -> 'TView -> 'TViewState
-    }
 
-type AppSpecification<'TModel, 'TMessage, 'TView, 'TViewState> = 
+type AppSpecification<'TModel, 'TMessage, 'TView> = 
     {
         InitState: 'TModel
         View: 'TModel -> 'TView
         Update: 'TModel -> 'TMessage -> ('TModel * Action<'TMessage> list)
         InitMessage: Action<'TMessage>
-        Renderer: Renderer<'TMessage, 'TView, 'TViewState>
+        CreateRenderer: Selector -> Handler<'TMessage> -> 'TView -> (Handler<'TMessage> -> 'TView -> unit)
         NodeSelector: Selector
         Producers: Producer<'TMessage, 'TModel> list
         Subscribers: Subscriber<'TMessage, 'TModel> list
     }
 
-type App<'TModel, 'TMessage, 'TViewState> =
+type App<'TModel, 'TMessage, 'TView> =
     {
         Model: 'TModel
         Actions: Action<'TMessage> list
-        ViewState: 'TViewState
+//        ViewState: 'TViewState
         RenderState: RenderState
+        Render: Handler<'TMessage> -> 'TView -> unit
     }
 
 [<AutoOpen>]
@@ -127,10 +125,10 @@ module internal Helpers =
         elem.addEventListener("FableArchEvent", eventHandler)
         post
 
-    let render post viewFn renderer app =
+    let render post viewFn app =
         let view = viewFn app.Model
-        let viewState' = renderer.Render post view app.ViewState
-        {app with ViewState = viewState'}
+        app.Render post view
+        app
 
     let executeActions post = List.iter (fun a -> a (Message >> post))
     let notifySubscribers subscribers msg = 
@@ -160,9 +158,9 @@ module internal Helpers =
 
         {app with Model = model; RenderState = renderState}
 
-    let handleDraw viewFn renderer post app = 
-        render post viewFn renderer app
-        |> (fun s -> {s with RenderState = NoRequest})
+    let handleDraw viewFn post app = 
+        render post viewFn app
+        |> (fun app -> {app with RenderState = NoRequest})
 
     let calculateModelChanges initState update actions = 
         let execUpdate r a =
@@ -178,7 +176,7 @@ module internal Helpers =
         actions
         |> List.fold (fun s a -> (execUpdate s a)::s) []
 
-    let handleReplay viewFn updateFn renderer subscribers post (fromModel, actions) app = 
+    let handleReplay viewFn updateFn subscribers post (fromModel, actions) app = 
         let result = calculateModelChanges fromModel updateFn actions
         let model = 
             match result with 
@@ -186,7 +184,7 @@ module internal Helpers =
             | [] -> fromModel
         let app' = 
             {app with Model = model}
-            |> render post viewFn renderer
+            |> render post viewFn
 
         (Replayed result) |> notifySubscribers subscribers
         app'
@@ -214,13 +212,13 @@ module AppApi =
     let toActionList a = [a]
 
     // Starting point for creating an application
-    let createApp state view update renderer =
+    let createApp state view update createRenderer =
         {
             InitState = state
             View = view
             Update = update
             InitMessage = (fun _ -> ())
-            Renderer = renderer
+            CreateRenderer = createRenderer
             NodeSelector = "body"
             Producers = []
             Subscribers = []
@@ -257,25 +255,23 @@ module AppApi =
         producers |> List.iter (fun p -> p post) 
 
     // Start the application
-    let start (appSpec:AppSpecification<'TModel, 'TMessage, 'TView, 'TViewState>) =
-        let renderer = appSpec.Renderer
-        let viewFn = appSpec.View
+    let start (appSpec:AppSpecification<'TModel, 'TMessage, 'TView>) =
+        let viewFn : ('TModel -> 'TView) = appSpec.View
         let updateFn = appSpec.Update
 
         let createInitApp post = 
-            let view = viewFn appSpec.InitState
-            let viewState = renderer.Init appSpec.NodeSelector post view
+            let view : 'TView = viewFn appSpec.InitState
             appSpec.InitMessage post
-            let render = appSpec.Renderer.Render
+            let render = appSpec.CreateRenderer appSpec.NodeSelector post view
 
             {
                 Model = appSpec.InitState
-                ViewState = viewState
+                Render = render
                 RenderState = NoRequest
                 Actions = []
             }
         let handleMessage' = handleMessage updateFn appSpec.Subscribers
-        let handleDraw' = handleDraw viewFn renderer
-        let handleReplay' = handleReplay viewFn updateFn renderer appSpec.Subscribers
+        let handleDraw' = handleDraw viewFn
+        let handleReplay' = handleReplay viewFn updateFn appSpec.Subscribers
         let configureProducers' = configureProducers appSpec.Producers
         application handleMessage' handleDraw' handleReplay' configureProducers' createInitApp

--- a/src/Fable.Arch/Fable.Arch.DevTools.fs
+++ b/src/Fable.Arch/Fable.Arch.DevTools.fs
@@ -402,7 +402,7 @@ let createDevTools<'TMessage, 'TModel> pluginId initModel=
     {
         Producer = (fun h -> linkAgent.Post(SetHandler h)) 
         Subscriber = (function 
-                        | ModelChanged m -> devToolsAgent.Post(Message (AddMessage (m.Message, m.CurrentState)))
-                        | Replayed modelList -> devToolsAgent.Post(Message (MessagesReplayed modelList))
+                        | ModelChanged m -> devToolsAgent (Message (AddMessage (m.Message, m.CurrentState)))
+                        | Replayed modelList -> devToolsAgent (Message (MessagesReplayed modelList))
                         | _ -> ())
     }

--- a/src/Fable.Arch/Fable.Arch.DevTools.fs
+++ b/src/Fable.Arch/Fable.Arch.DevTools.fs
@@ -389,7 +389,7 @@ let createDevTools<'TMessage, 'TModel> pluginId initModel=
     )
 
     let devToolsAgent = 
-        createApp {Base = initModel; Actions = []; Collapsed = Map.empty; LastCommited =[initModel]} devToolsView devToolsUpdate Virtualdom.renderer
+        createApp {Base = initModel; Actions = []; Collapsed = Map.empty; LastCommited =[initModel]} devToolsView devToolsUpdate Virtualdom.createRender
         |> withStartNodeSelector "#___devtools"
         |> withInstrumentationSubscriber (
             fun ae -> 

--- a/src/Fable.Arch/Fable.Arch.Navigation.fs
+++ b/src/Fable.Arch/Fable.Arch.Navigation.fs
@@ -87,22 +87,24 @@ let withNavigation parser urlUpdate app =
 
     let initMessage = mapAction Message app.InitMessage
 
-    let renderer =
-        let render h =
-            app.Renderer.Render (Message >> h) 
-        let init sel h = 
-            app.Renderer.Init sel (Message >> h)
-        {
-            Render = render
-            Init = init
-        }
+    let mapCreateRenderer createRenderer =
+        let mapRenderer renderer = 
+            let renderer' handler view =
+                renderer (Message >> handler) view
+            renderer'
 
+        let createRenderer' sel handler view = 
+            createRenderer sel (Message >> handler) view
+            |> mapRenderer
+        createRenderer'
+
+    let createRenderer = mapCreateRenderer app.CreateRenderer
     {
         InitState = app.InitState
         View = app.View
         Update = update'
         InitMessage = initMessage 
-        Renderer = renderer
+        CreateRenderer = createRenderer
         NodeSelector = app.NodeSelector
         Producers = producers
         Subscribers = subscribers

--- a/src/Fable.Arch/Fable.Arch.Virtualdom.fs
+++ b/src/Fable.Arch/Fable.Arch.Virtualdom.fs
@@ -60,29 +60,23 @@ let rec renderSomething handler node =
     | Text str -> box(string str)
     | WhiteSpace str -> box(string str)
 
-
 let render handler view viewState =
     let tree = renderSomething handler view
     {viewState with CurrentTree = tree}
 
-let init selector handler view = 
+let createRender selector handler view =
     let node = document.body.querySelector(selector) :?> HTMLElement
     let tree = renderSomething handler view
     let vdomNode = createElement tree
     node.appendChild(vdomNode) |> ignore
-    {
-        CurrentTree = tree
-        Node = vdomNode
-    }    
-
-let render' handler view viewState = 
-    let viewState' = render handler view viewState
-    let patches = diff viewState.CurrentTree viewState'.CurrentTree
-    patch viewState.Node patches |> ignore
-    viewState'
-
-let renderer =
-    {
-        Render = render'
-        Init = init
-    }
+    let mutable viewState = 
+        {
+            CurrentTree = tree
+            Node = vdomNode
+        }
+    let render' handler view = 
+        let viewState' = render handler view viewState
+        let patches = diff viewState.CurrentTree viewState'.CurrentTree
+        patch viewState.Node patches |> ignore
+        viewState <- viewState'
+    render'

--- a/src/Fable.Arch/package.json
+++ b/src/Fable.Arch/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fable-arch",
-    "version": "0.9.6",
+    "version": "0.9.7",
     "description": "Fable Arch is a generic version of the elm architecture implemented with Fable in F#.",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Two commits:
- The first remove the mailboxprocessor from the core. Mainly to reduce complexity and instead use native js events.
- The second removes the view state type, that is something that should be kept internally in a renderer.
