### PR TITLE
add new vnode function to inject virtual-dom in view

### DIFF
--- a/src/Fable.Arch/Fable.Arch.Html.fs
+++ b/src/Fable.Arch/Fable.Arch.Html.fs
@@ -28,6 +28,7 @@ module Types =
     /// Whitespace for formatting
     | WhiteSpace of string
     | Svg of Element<'TMessage> * DomNode<'TMessage> list
+    | VirtualNode of string * Map<string, string> * obj[]
 
 let mapEventHandler<'T1,'T2> (mapping:('T1 -> 'T2)) (e,f) = EventHandler(e, f >> mapping)
 
@@ -53,6 +54,7 @@ let rec map<'T1,'T2> (mapping:('T1 -> 'T2)) (node:DomNode<'T1>) =
     | Text(s) -> Text s
     | WhiteSpace(ws) -> WhiteSpace ws
     | Svg(e,ns) -> Element(mapElem mapping e, ns |> List.map (map mapping))
+    | VirtualNode(tag, props, childrens) -> VirtualNode(tag, props, childrens)
 
 [<AutoOpen>]
 module Tags =
@@ -62,6 +64,8 @@ module Tags =
     let whiteSpace x = WhiteSpace x
     let text x = Text x
 
+    let vnode tag props children = VirtualNode(tag, props, children)
+    
     // Elements - list of elements here: https://developer.mozilla.org/en-US/docs/Web/HTML/Element
     // Void elements
     let br x = voidElem "br" x

--- a/src/Fable.Arch/Fable.Arch.Virtualdom.fs
+++ b/src/Fable.Arch/Fable.Arch.Virtualdom.fs
@@ -66,6 +66,7 @@ let rec renderSomething handler node =
     | VoidElement (tag, attrs) -> createTree handler tag attrs []
     | Text str -> box(string str)
     | WhiteSpace str -> box(string str)
+    | VirtualNode(tag, props, childrens) -> h(tag, props, childrens)
 
 let render handler view viewState =
     let tree = renderSomething handler view


### PR DESCRIPTION
Offer a possibility to inject a virtual-dom tree generated by another library in a view coded in F#

```fsharp
let render linkPrefix markdown =
  remark()
    .``use``(hljs)
    .``use``(vdom, { components = components linkPrefix })
    .``process``(markdown)
    .contents

//--------------------------
div [ classy "container doc-main" ] [
    div [ classy "row" ] [
      div [ classy "col-sm-8" ] [ 
        render ("#/" + context.libraryId + "/")  content |> unbox |> vnode
      ]
      sidebarMenu context
    ]
  ]
```