### PR TITLE
Added canvas rendering context hook, canvas element and other stuff.

### DIFF
--- a/src/Fable.Arch/Fable.Arch.Html.fs
+++ b/src/Fable.Arch/Fable.Arch.Html.fs
@@ -233,13 +233,6 @@ module Attributes =
     /// class attribute helper
     let classy value = attribute "class" value
 
-    let className name = attribute "class" name
-    let height (n: int) = attribute "height" (string n)
-    let width (n: int) = attribute "width" (string n)
-    let src url = attribute "src" url
-    let href url = attribute "href" url
-    let placeholder input = attribute "placeholder" input
-
     /// Provides means to interact with inner rendering contex of a canvas 
     let canvasContextHook (ctxHandler: CanvasRenderingContext2D -> unit) = 
         hook "canvas-ctx" (HookHelper.CreateHook (fun el _ _ -> 

--- a/src/Fable.Arch/Fable.Arch.Html.fs
+++ b/src/Fable.Arch/Fable.Arch.Html.fs
@@ -164,6 +164,9 @@ module Tags =
     let objectHtml x = elem "object" x
     let iframe x = elem "iframe" x
 
+    // canvas 
+    let canvas x = elem "canvas" x
+
     // Demarcasting edits
     let del x = elem "del" x
     let ins x = elem "ins" x
@@ -229,6 +232,21 @@ module Attributes =
 
     /// class attribute helper
     let classy value = attribute "class" value
+
+    let className name = attribute "class" name
+    let height (n: int) = attribute "height" (string n)
+    let width (n: int) = attribute "width" (string n)
+    let src url = attribute "src" url
+    let href url = attribute "href" url
+    let placeholder input = attribute "placeholder" input
+
+    /// Provides means to interact with inner rendering contex of a canvas 
+    let canvasContextHook (ctxHandler: CanvasRenderingContext2D -> unit) = 
+        hook "canvas-ctx" (HookHelper.CreateHook (fun el _ _ -> 
+            let canvas = unbox<HTMLCanvasElement> el
+            let ctx = canvas.getContext_2d()
+            ctxHandler ctx
+        ))
 
     /// Helper to build space separated class
     let classList (list: (string*bool) seq) =


### PR DESCRIPTION
the `canvasContextHook` provides means to interact with the rendering context after every message dispatch in dispatch loop of the app. To be used as follows:

```fsharp
type Message = Incr | Decr

let update count = function 
    | Incr -> count + 1
    | Decr -> count - 1

let view (model:int) = 
    div 
      []
      [
          button [ onMouseClick (fun _ -> Incr) ] [ text "increment" ]
          canvas 
            [
              height 300
              width 300
              canvasContextHook (fun ctx -> 
                  ctx.rect(20.0, 20.0, 150.0, float (model * 5))
                  ctx.stroke()
              )  
            ] []
      ]

createSimpleApp 0 view update Virtualdom.createRender
|> withStartNodeSelector "#sample"
|> start
```

Other stuff is just commonly used attribures such as `height`, `width`, `href` etc.