### PR TITLE
Fix typo: createRender => createRenderer

### DIFF
--- a/docs/doc_files/subscriber.md
+++ b/docs/doc_files/subscriber.md
@@ -22,7 +22,7 @@ type ModelChanged<'TMessage, 'TModel> =
 Here a sample, showing how to print in the console all the message handle by the app.
 
 ```fsharp
-createApp Model.Initial view update Virtualdom.createRender
+createApp Model.Initial view update Virtualdom.createRenderer
 |> withStartNodeSelector "#app"
 // Here is the subscriber
 |> withSubscriber (fun x -> console.log("Action received:", x.Message))

--- a/docs/samples/calculator/README.md
+++ b/docs/samples/calculator/README.md
@@ -195,7 +195,7 @@ div
 # Create the app
 ```fsharp
 let initialState = InputStack []
-createSimpleApp initialState view update Virtualdom.createRender
+createSimpleApp initialState view update Virtualdom.createRenderer
 |> withStartNodeSelector "#calc"
 |> start
 ```

--- a/docs/samples/calculator/sample.fsx
+++ b/docs/samples/calculator/sample.fsx
@@ -175,6 +175,6 @@ let view model =
 // some of the other more advanced examples for how to
 // use createApp. In addition to the application functions
 // we also need to specify which renderer to use.
-createSimpleApp (InputStack []) view update Virtualdom.createRender
+createSimpleApp (InputStack []) view update Virtualdom.createRenderer
 |> withStartNodeSelector "#sample"
 |> start

--- a/docs/samples/clock/README.md
+++ b/docs/samples/clock/README.md
@@ -77,7 +77,7 @@ let tickProducer push =
 To a register a producer in your application you need to call `withProducer`.
 
 ```fsharp
-createApp Model.Initial view update Virtualdom.createRender
+createApp Model.Initial view update Virtualdom.createRenderer
 |> withStartNodeSelector "#sample"
 |> withProducer tickProducer
 |> start

--- a/docs/samples/clock/sample.fsx
+++ b/docs/samples/clock/sample.fsx
@@ -72,7 +72,7 @@ module Clock =
     push(Tick DateTime.Now)
 
 
-  createApp Model.Initial view update Virtualdom.createRender
+  createApp Model.Initial view update Virtualdom.createRenderer
   |> withStartNodeSelector "#sample"
   |> withProducer tickProducer
   |> start

--- a/docs/samples/counter/sample.fsx
+++ b/docs/samples/counter/sample.fsx
@@ -71,6 +71,6 @@ let view model =
     ]
 
 
-createSimpleApp Model.Initial view update Virtualdom.createRender
+createSimpleApp Model.Initial view update Virtualdom.createRenderer
 |> withStartNodeSelector "#sample"
 |> start

--- a/docs/samples/echo/sample.fsx
+++ b/docs/samples/echo/sample.fsx
@@ -138,6 +138,6 @@ let view model =
     ]
 
 
-createApp Model.Initial view update Virtualdom.createRender
+createApp Model.Initial view update Virtualdom.createRenderer
 |> withStartNodeSelector "#sample"
 |> start

--- a/docs/samples/hello/sample.fsx
+++ b/docs/samples/hello/sample.fsx
@@ -56,6 +56,6 @@ let view (model: Model) =
 // some of the other more advanced examples for how to
 // use createApp. In addition to the application functions
 // we also need to specify which renderer to use.
-createSimpleApp "" view update Virtualdom.createRender
+createSimpleApp "" view update Virtualdom.createRenderer
 |> withStartNodeSelector "#sample"
 |> start

--- a/docs/samples/navigation/README.md
+++ b/docs/samples/navigation/README.md
@@ -53,7 +53,7 @@ let update model action =
 We attach the navigation module by passing the `urlParser` and `navigationUpdate`.
 
 ```fsharp
-createApp Model.Initial view update Virtualdom.createRender
+createApp Model.Initial view update Virtualdom.createRenderer
 |> withStartNodeSelector "#sample"
 |> withNavigation urlParser navigationUpdate
 |> start

--- a/docs/samples/navigation/sample.fsx
+++ b/docs/samples/navigation/sample.fsx
@@ -84,7 +84,7 @@ let view model =
       div [ classy "column" ] []
     ]
 
-createApp Model.Initial view update Virtualdom.createRender
+createApp Model.Initial view update Virtualdom.createRenderer
 |> withStartNodeSelector "#sample"
 |> withNavigation urlParser navigationUpdate
 |> start

--- a/docs/samples/nestedcounter/sample.fsx
+++ b/docs/samples/nestedcounter/sample.fsx
@@ -180,6 +180,6 @@ let view model =
         VDom.column<Actions>
       ] :: countersView)
 
-createApp Model.Initial view update Virtualdom.createRender
+createApp Model.Initial view update Virtualdom.createRenderer
 |> withStartNodeSelector "#sample"
 |> start

--- a/docs/samples/routing/README.md
+++ b/docs/samples/routing/README.md
@@ -88,7 +88,7 @@ let routerF m = router.Route m.Message
 With attach our helpers to the application.
 
 ```fsharp
-createApp Model.Initial view update Virtualdom.createRender
+createApp Model.Initial view update Virtualdom.createRenderer
 |> withStartNodeSelector "#sample"
 |> withProducer (routeProducer locationHandler router)
 |> withSubscriber (routeSubscriber locationHandler routerF)

--- a/docs/samples/routing/sample.fsx
+++ b/docs/samples/routing/sample.fsx
@@ -262,7 +262,7 @@ let view model =
 // some of the other more advanced examples for how to
 // use createApp. In addition to the application functions
 // we also need to specify which renderer to use.
-createApp Model.Initial view update Virtualdom.createRender
+createApp Model.Initial view update Virtualdom.createRenderer
 |> withStartNodeSelector "#sample"
 |> withProducer (routeProducer locationHandler router)
 |> withSubscriber (routeSubscriber locationHandler routerF)

--- a/docs/samples/subscriber/README.md
+++ b/docs/samples/subscriber/README.md
@@ -12,7 +12,7 @@ This function signature is `(ModelChanged<'a,'b> -> unit) -> app:AppSpecificatio
 So we need to provide it with a function taking a `ModelChanged` argument and return unit. We also need to pass it the `AppSpecification` on which to attach.
 
 ```fsharp
-createSimpleApp "" view update Virtualdom.createRender
+createSimpleApp "" view update Virtualdom.createRenderer
 |> withStartNodeSelector "#sample"
 // Next line is how we register the subscriber
 |> withSubscriber (fun x -> Fable.Import.Browser.console.log("Event received: ", x))

--- a/docs/samples/subscriber/sample.fsx
+++ b/docs/samples/subscriber/sample.fsx
@@ -51,7 +51,7 @@ let view (model: Model) =
       div [ classy "column" ] []
     ]
 
-createSimpleApp "" view update Virtualdom.createRender
+createSimpleApp "" view update Virtualdom.createRenderer
 |> withStartNodeSelector "#sample"
 |> withSubscriber (fun x -> Fable.Import.Browser.console.log("Event received: ", x))
 |> start

--- a/docs/samples/template/sample.fsx
+++ b/docs/samples/template/sample.fsx
@@ -29,6 +29,6 @@ let view (model: Model) =
 // some of the other more advanced examples for how to
 // use createApp. In addition to the application functions
 // we also need to specify which renderer to use.
-createSimpleApp "" view update Virtualdom.createRender
+createSimpleApp "" view update Virtualdom.createRenderer
 |> withStartNodeSelector "#sample"
 |> start

--- a/docs/src/App.fs
+++ b/docs/src/App.fs
@@ -236,7 +236,7 @@ module Main =
 
   let routerF m = router.Route m.Message
 
-  createApp Model.Initial view update Virtualdom.createRender
+  createApp Model.Initial view update Virtualdom.createRenderer
   |> withStartNodeSelector "#app"
   |> withProducer (routeProducer locationHandler router)
   |> withSubscriber (routeSubscriber locationHandler routerF)

--- a/src/Fable.Arch/Fable.Arch.DevTools.fs
+++ b/src/Fable.Arch/Fable.Arch.DevTools.fs
@@ -404,7 +404,7 @@ let createDevTools<'TMessage, 'TModel> pluginId initModel=
                 LastCommited = None
                 PushToApp = (fun m -> linkAgent.Post (Push (AppMessage.Replay m)))
             }
-        createApp initModel devToolsView devToolsUpdate Virtualdom.createRender
+        createApp initModel devToolsView devToolsUpdate Virtualdom.createRenderer
         |> withStartNodeSelector "#___devtools"
         |> startAndExposeMessageSink 
     

--- a/src/Fable.Arch/Fable.Arch.Virtualdom.fs
+++ b/src/Fable.Arch/Fable.Arch.Virtualdom.fs
@@ -73,7 +73,7 @@ let render handler view viewState =
     let tree = renderSomething handler view
     {viewState with NextTree = tree}
 
-let createRender selector handler view =
+let createRenderer selector handler view =
     let node = 
         match selector with
         | Query sel -> document.body.querySelector(sel) :?> HTMLElement


### PR DESCRIPTION
This is an inconsistency between React and Virtualdom implementations, and I believe a regression from a previous version